### PR TITLE
cofig gpu id used & mkdir dataset to point where the different dataset is.

### DIFF
--- a/dataset/Readme.md
+++ b/dataset/Readme.md
@@ -1,0 +1,22 @@
+* SceneFlow includes three datasets: flything3d, driving and monkaa.
+* You can train PSMNet with some of three datasets, or all of them.
+* the following is the describtion of six subfolder.
+```
+# the disp folder of Driving dataset
+driving_disparity  
+# the image folder of Driving dataset
+driving_frames_cleanpass
+
+# the disp folder of  Flything3D dataset
+frames_cleanpass  
+# the image folder of  Flything3D dataset
+frames_disparity  
+
+# the disp folder of Monkaa dataset
+monkaa_disparity  
+# the image folder of Monkaa dataset
+monkaa_frames_cleanpass
+```
+* Download the dataset from [this](https://lmb.informatik.uni-freiburg.de/resources/datasets/SceneFlowDatasets.en.html). And unzip them to corresponding folder.
+
+* `data_scene_flow_2015` is the folder for kitti15. You can unzip kitti15 to this folder. This will be used in **test** pahse.

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ parser.add_argument('--maxdisp', type=int ,default=192,
                     help='maxium disparity')
 parser.add_argument('--model', default='stackhourglass',
                     help='select model')
-parser.add_argument('--datapath', default='/media/jiaren/ImageNet/SceneFlowData/',
+parser.add_argument('--datapath', default='dataset/',
                     help='datapath')
 parser.add_argument('--epochs', type=int, default=10,
                     help='number of epochs to train')

--- a/main.py
+++ b/main.py
@@ -37,6 +37,9 @@ parser.add_argument('--seed', type=int, default=1, metavar='S',
 args = parser.parse_args()
 args.cuda = not args.no_cuda and torch.cuda.is_available()
 
+# set gpu id used
+os.environ["CUDA_VISIBLE_DEVICES"] = "0,1"
+
 torch.manual_seed(args.seed)
 if args.cuda:
     torch.cuda.manual_seed(args.seed)

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 python main.py --maxdisp 192 \
                --model stackhourglass \
-               --datapath /media/jiaren/ImageNet/SceneFlowData/ \
+               --datapath dataset/ \
                --epochs 0 \
                --loadmodel ./trained/checkpoint_10.tar \
                --savemodel ./trained/
@@ -12,7 +12,7 @@ python main.py --maxdisp 192 \
 python finetune.py --maxdisp 192 \
                    --model stackhourglass \
                    --datatype 2015 \
-                   --datapath /media/jiaren/ImageNet/data_scene_flow_2015/training/ \
+                   --datapath dataset/data_scene_flow_2015/training/ \
                    --epochs 300 \
                    --loadmodel ./trained/checkpoint_10.tar \
                    --savemodel ./trained/


### PR DESCRIPTION
* use `os.environ["CUDA_VISIBLE_DEVICES"] = "0,1"` to config which gpus are used.
* create `dataset` folder, and modifed `run.sh` and main.py. it is easier for users to understand where flyingthing3d, mokaa and driving should put.